### PR TITLE
Feature/author resolvers

### DIFF
--- a/daos/authors.go
+++ b/daos/authors.go
@@ -52,7 +52,13 @@ func FindAuthorByLastName(ctx context.Context, lname string) (*models.Author, er
 		One(ctx, contextExecutor)
 }
 
-func GetAllAuthors(ctx context.Context, queries ...qm.QueryMod) (models.AuthorSlice, error) {
+func GetAllAuthorsWithCount(ctx context.Context, queries ...qm.QueryMod) (models.AuthorSlice, int64, error) {
 	contextExecutor := GetContextExecutor(nil)
-	return models.Authors(queries...).All(ctx, contextExecutor)
+
+	count, err := models.Authors().Count(ctx, contextExecutor)
+	if err != nil {
+		return models.AuthorSlice{}, 0, err
+	}
+	authors, err := models.Authors(queries...).All(ctx, contextExecutor)
+	return authors, count, err
 }

--- a/pkg/utl/cnvrttogql/cnvrttogql.go
+++ b/pkg/utl/cnvrttogql/cnvrttogql.go
@@ -2,13 +2,14 @@ package cnvrttogql
 
 import (
 	"context"
+	"strconv"
+
+	"github.com/volatiletech/sqlboiler/v4/boil"
+
 	graphql "go-template/gqlmodels"
 	"go-template/internal/constants"
 	"go-template/models"
 	"go-template/pkg/utl/convert"
-	"strconv"
-
-	"github.com/volatiletech/sqlboiler/v4/boil"
 )
 
 // UsersToGraphQlUsers converts array of type models.User into array of pointer type graphql.User
@@ -69,4 +70,27 @@ func RoleToGraphqlRole(r *models.Role, count int) *graphql.Role {
 		DeletedAt:   convert.NullDotTimeToPointerInt(r.DeletedAt),
 		Users:       UsersToGraphQlUsers(users, count),
 	}
+}
+
+func AuthorToGraphQlAuthor(a models.Author) *graphql.Author {
+	return &graphql.Author{
+		ID:        strconv.Itoa(a.ID),
+		FirstName: a.FirstName,
+		LastName:  a.LastName.String,
+		CreatedAt: convert.NullDotTimeToPointerInt(a.CreatedAt),
+		UpdatedAt: convert.NullDotTimeToPointerInt(a.UpdatedAt),
+		DeletedAt: convert.NullDotTimeToPointerInt(a.DeletedAt),
+	}
+}
+
+func AuthorsToGraphQlAuthorsPayload(authors models.AuthorSlice, total int64) *graphql.AuthorsPayload {
+	result := graphql.AuthorsPayload{
+		Authors: make([]*graphql.Author, 0, len(authors)),
+		Total:   int(total),
+	}
+
+	for i := range authors {
+		result.Authors = append(result.Authors, AuthorToGraphQlAuthor(*authors[i]))
+	}
+	return &result
 }

--- a/resolver/author_mutation.resolvers_test.go
+++ b/resolver/author_mutation.resolvers_test.go
@@ -1,0 +1,212 @@
+package resolver_test
+
+import (
+	"context"
+	"fmt"
+	"go-template/daos"
+	fm "go-template/gqlmodels"
+	"go-template/models"
+	"go-template/resolver"
+	"go-template/testutls"
+	"testing"
+	"time"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/volatiletech/null/v8"
+)
+
+func TestCreateAuthor(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      fm.AuthorCreateInput
+		wantResp *fm.Author
+		wantErr  bool
+		init     func() *gomonkey.Patches
+	}{
+		{
+			name: "Should create Author",
+			req: fm.AuthorCreateInput{
+				FirstName: "First",
+				LastName:  "Last",
+			},
+			wantResp: &fm.Author{
+				ID:        fmt.Sprintf("%d", testutls.MockID),
+				FirstName: "First",
+				LastName:  "Last",
+			},
+			wantErr: false,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.CreateAuthor, func(ctx context.Context, author models.Author) (models.Author, error) {
+					return *testutls.MockAuthor(), nil
+				})
+			},
+		},
+		{
+			name: "Should not create Author",
+			req: fm.AuthorCreateInput{
+				FirstName: "First",
+			},
+			wantResp: nil,
+			wantErr:  true,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.CreateAuthor, func(ctx context.Context, author models.Author) (models.Author, error) {
+					return models.Author{}, fmt.Errorf("Last name is required")
+				})
+			},
+		},
+	}
+	resolver := resolver.Resolver{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// setup and tear down monkey patch
+			patch := test.init()
+			defer func() {
+				if patch != nil {
+					patch.Reset()
+				}
+			}()
+			// sleep to reset the monkey patch
+			time.Sleep(10 * time.Millisecond)
+
+			response, err := resolver.Mutation().CreateAuthor(context.Background(), test.req)
+			assert.Equal(t, test.wantErr, err != nil)
+			if err == nil {
+				assert.Equal(t, test.wantResp, response)
+			}
+		})
+	}
+}
+
+// nolint: funlen
+func TestUpdateAuthor(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      fm.AuthorUpdateInput
+		wantResp *fm.Author
+		wantErr  bool
+		init     func() *gomonkey.Patches
+	}{
+		{
+			name: "Should update Author",
+			req: fm.AuthorUpdateInput{
+				ID:        "1",
+				FirstName: &testutls.MockAuthor().FirstName,
+			},
+			wantResp: &fm.Author{
+				ID:        "1",
+				FirstName: testutls.MockAuthor().FirstName,
+				LastName:  testutls.MockAuthor().LastName.String,
+			},
+			wantErr: false,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return testutls.MockAuthor(), nil
+				}).ApplyFunc(daos.UpdateAuthor, func(ctx context.Context, author models.Author) (models.Author, error) {
+					return *testutls.MockAuthor(), nil
+				})
+			},
+		},
+		{
+			name: "Should not update Author",
+			req: fm.AuthorUpdateInput{
+				ID:        "fjdk",
+				FirstName: &testutls.MockAuthor().FirstName,
+			},
+			wantResp: nil,
+			wantErr:  true,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return nil, fmt.Errorf("no such author")
+				})
+			},
+		},
+	}
+
+	resolver := resolver.Resolver{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patch := test.init()
+			defer func() {
+				if patch != nil {
+					patch.Reset()
+				}
+			}()
+			time.Sleep(10 * time.Millisecond)
+			resp, err := resolver.Mutation().UpdateAuthor(context.Background(), test.req)
+			assert.Equal(t, test.wantErr, err != nil, "expected: %t got: %v", test.wantErr, err)
+			if err == nil {
+				assert.Equal(t, test.wantResp, resp)
+			}
+		})
+	}
+}
+
+// nolint: funlen
+func TestDeleteAuthor(t *testing.T) {
+	tests := []struct {
+		name     string
+		req      fm.AuthorDeleteInput
+		wantResp *fm.Author
+		wantErr  bool
+		init     func() *gomonkey.Patches
+	}{
+		{
+			name: "Should delete Author",
+			req: fm.AuthorDeleteInput{
+				ID: "33",
+			},
+			wantResp: &fm.Author{
+				ID:        "33",
+				FirstName: "fname",
+				LastName:  "lname",
+			},
+			wantErr: false,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return &models.Author{
+						ID:        33,
+						FirstName: "fname",
+						LastName:  null.StringFrom("lname"),
+					}, nil
+				}).ApplyFunc(daos.DeleteAuthor, func(ctx context.Context, author models.Author) (int64, error) {
+					return 1, nil
+				})
+			},
+		},
+		{
+			name: "Should not delete Author",
+			req: fm.AuthorDeleteInput{
+				ID: "fjdk",
+			},
+			wantResp: nil,
+			wantErr:  true,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return nil, fmt.Errorf("no such author")
+				})
+			},
+		},
+	}
+
+	resolver := resolver.Resolver{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patch := test.init()
+			defer func() {
+				if patch != nil {
+					patch.Reset()
+				}
+			}()
+			time.Sleep(10 * time.Millisecond)
+			resp, err := resolver.Mutation().DeleteAuthor(context.Background(), test.req)
+			assert.Equal(t, test.wantErr, err != nil, "expected: %t got: %v", test.wantErr, err)
+			if err == nil {
+				assert.Equal(t, test.wantResp, resp)
+			}
+		})
+	}
+}

--- a/resolver/author_mutations.resolvers.go
+++ b/resolver/author_mutations.resolvers.go
@@ -6,21 +6,70 @@ package resolver
 
 import (
 	"context"
-	"fmt"
+
+	"github.com/volatiletech/null/v8"
+
+	"go-template/daos"
 	"go-template/gqlmodels"
+	"go-template/models"
+	"go-template/pkg/utl/cnvrttogql"
+	"go-template/pkg/utl/convert"
+	"go-template/pkg/utl/resultwrapper"
 )
 
 // CreateAuthor is the resolver for the createAuthor field.
 func (r *mutationResolver) CreateAuthor(ctx context.Context, input gqlmodels.AuthorCreateInput) (*gqlmodels.Author, error) {
-	panic(fmt.Errorf("not implemented: CreateAuthor - createAuthor"))
+	newAuthor, err := daos.CreateAuthor(ctx, models.Author{
+		FirstName: input.FirstName,
+		LastName:  null.StringFrom(input.LastName),
+	})
+	if err != nil {
+		return nil, resultwrapper.ResolverSQLError(err, "author insertion")
+	}
+	return cnvrttogql.AuthorToGraphQlAuthor(newAuthor), nil
 }
 
 // UpdateAuthor is the resolver for the updateAuthor field.
 func (r *mutationResolver) UpdateAuthor(ctx context.Context, input gqlmodels.AuthorUpdateInput) (*gqlmodels.Author, error) {
-	panic(fmt.Errorf("not implemented: UpdateAuthor - updateAuthor"))
+	// Fetch the author
+	author, err := daos.FindAuthorByID(ctx, convert.StringToInt(input.ID))
+	if err != nil {
+		return nil, resultwrapper.ResolverSQLError(err, "find author by id")
+	}
+
+	// Update Author with with with given input, if they are non null
+	if input.FirstName != nil {
+		author.FirstName = *input.FirstName
+	}
+	if input.LastName != nil {
+		author.LastName = null.StringFrom(*input.LastName)
+	}
+
+	// Update Author in the DB
+	updatedAuthor, err := daos.UpdateAuthor(ctx, *author)
+	if err != nil {
+		return nil, resultwrapper.ResolverSQLError(err, "update author")
+	}
+	// Return the updated Author
+	return cnvrttogql.AuthorToGraphQlAuthor(updatedAuthor), nil
 }
 
 // DeleteAuthor is the resolver for the deleteAuthor field.
 func (r *mutationResolver) DeleteAuthor(ctx context.Context, input gqlmodels.AuthorDeleteInput) (*gqlmodels.Author, error) {
-	panic(fmt.Errorf("not implemented: DeleteAuthor - deleteAuthor"))
+	// Fetch the author
+	author, err := daos.FindAuthorByID(ctx, convert.StringToInt(input.ID))
+	if err != nil {
+		return nil, resultwrapper.ResolverSQLError(err, "find author by id")
+	}
+
+	// Delete the author
+	deletedCount, err := daos.DeleteAuthor(ctx, *author)
+	if err != nil {
+		return nil, resultwrapper.ResolverSQLError(err, "delete author")
+	}
+	if deletedCount == 0 {
+		return nil, resultwrapper.ResolverWrapperFromMessage(500, "no author deleted")
+	}
+
+	return cnvrttogql.AuthorToGraphQlAuthor(*author), nil
 }

--- a/resolver/author_queries.resolvers_test.go
+++ b/resolver/author_queries.resolvers_test.go
@@ -1,0 +1,197 @@
+package resolver_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"go-template/daos"
+	fm "go-template/gqlmodels"
+	"go-template/models"
+	"go-template/resolver"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/volatiletech/null/v8"
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+)
+
+// nolint: funlen
+func TestAuthor(t *testing.T) {
+	now := time.Now()
+	nowMilli := int(time.Now().UnixMilli())
+	tests := []struct {
+		name       string
+		inputID    string
+		wantAuthor *fm.Author
+		wantErr    bool
+		init       func() *gomonkey.Patches
+	}{
+		{
+			name:    "Should get author with id 2",
+			inputID: "2",
+			wantAuthor: &fm.Author{
+				ID:        "2",
+				FirstName: "John",
+				LastName:  "Doe",
+				CreatedAt: &nowMilli,
+				UpdatedAt: &nowMilli,
+			},
+			wantErr: false,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return &models.Author{
+						ID:        2,
+						FirstName: "John",
+						LastName:  null.StringFrom("Doe"),
+						CreatedAt: null.TimeFrom(now),
+						UpdatedAt: null.TimeFrom(now),
+					}, nil
+				})
+			},
+		},
+		{
+			name:       "Should return error for input id 'hi'",
+			inputID:    "hi",
+			wantAuthor: nil,
+			wantErr:    true,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(daos.FindAuthorByID, func(ctx context.Context, id int) (*models.Author, error) {
+					return nil, fmt.Errorf("no such author for id 'hi'")
+				})
+			},
+		},
+	}
+
+	resolver := resolver.Resolver{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patch := test.init()
+			defer func() {
+				if patch != nil {
+					patch.Reset()
+				}
+			}()
+			time.Sleep(10 * time.Millisecond)
+
+			author, err := resolver.Query().Author(context.Background(), test.inputID)
+			assert.Equal(t, test.wantErr, err != nil,
+				"wantErr: %t, got: %v", test.wantErr, err,
+			)
+			assert.Equal(t, author, test.wantAuthor)
+		})
+	}
+}
+
+// nolint: funlen
+func TestAuthors(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       fm.Pagination
+		wantPayload *fm.AuthorsPayload
+		wantErr     bool
+		init        func() *gomonkey.Patches
+	}{
+		{
+			name: "Should return 2 authors out of 20 ",
+			input: fm.Pagination{
+				Limit: 2,
+				Page:  1,
+			},
+			wantPayload: &fm.AuthorsPayload{
+				Authors: []*fm.Author{
+					{
+						ID:        "1",
+						FirstName: "author_first01",
+						LastName:  "author_last01",
+					},
+					{
+						ID:        "2",
+						FirstName: "author_first02",
+						LastName:  "author_last02",
+					},
+				},
+				Total: 20,
+			},
+			wantErr: false,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(
+					daos.GetAllAuthorsWithCount,
+					func(ctx context.Context, queries ...qm.QueryMod) (models.AuthorSlice, int64, error) {
+						return []*models.Author{
+							{
+								ID:        1,
+								FirstName: "author_first01",
+								LastName:  null.StringFrom("author_last01"),
+							},
+							{
+								ID:        2,
+								FirstName: "author_first02",
+								LastName:  null.StringFrom("author_last02"),
+							},
+						}, 20, nil
+					})
+			},
+		},
+		{
+			name: "Should return sql error",
+			input: fm.Pagination{
+				Limit: 2,
+				Page:  1,
+			},
+			wantPayload: nil,
+			wantErr:     true,
+			init: func() *gomonkey.Patches {
+				return gomonkey.ApplyFunc(
+					daos.GetAllAuthorsWithCount,
+					func(ctx context.Context, queries ...qm.QueryMod) (models.AuthorSlice, int64, error) {
+						return models.AuthorSlice{}, 0, fmt.Errorf("sql error")
+					})
+			},
+		},
+		{
+			name: "Should return validation error for negative limit",
+			input: fm.Pagination{
+				Limit: -2,
+				Page:  1,
+			},
+			wantPayload: nil,
+			wantErr:     true,
+			init: func() *gomonkey.Patches {
+				return nil
+			},
+		},
+		{
+			name: "Should return validation error for negative page",
+			input: fm.Pagination{
+				Limit: 2,
+				Page:  -1,
+			},
+			wantPayload: nil,
+			wantErr:     true,
+			init: func() *gomonkey.Patches {
+				return nil
+			},
+		},
+	}
+
+	resolver := resolver.Resolver{}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			patch := test.init()
+			defer func() {
+				if patch != nil {
+					patch.Reset()
+				}
+			}()
+			time.Sleep(10 * time.Millisecond)
+			authorPayload, err := resolver.Query().Authors(context.Background(), test.input)
+			assert.Equal(t, test.wantErr, err != nil,
+				"wantErr: %t, got: %v", test.wantErr, err,
+			)
+			assert.Equal(t, authorPayload, test.wantPayload)
+		})
+	}
+}


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
- Adds resolver for mutation and queries of `Author` entity
- Refactor `GetAllAuthor` to return the count of `Author` entity in the table


### Steps to Reproduce / Test
---------------------------------------------------
- Run `go test -gcflags=all=-l go-template/resolver`

- NOTE:
  - Some test from `auth resolver` are failing due to `nil pointer dereference`
  - The cause of the above bug is unknown for now, they appeared after the introduction of `author` and `post` resolvers



### Request
---------------------------------------------------


### Response
---------------------------------------------------
