### PR TITLE
fix: author mutations where id can be get from context

### DIFF
--- a/gqlmodels/generated.go
+++ b/gqlmodels/generated.go
@@ -75,7 +75,7 @@ type ComplexityRoot struct {
 		CreatePost     func(childComplexity int, input PostCreateInput) int
 		CreateRole     func(childComplexity int, input RoleCreateInput) int
 		CreateUser     func(childComplexity int, input UserCreateInput) int
-		DeleteAuthor   func(childComplexity int, input AuthorDeleteInput) int
+		DeleteAuthor   func(childComplexity int) int
 		DeletePost     func(childComplexity int, input PostDeleteInput) int
 		DeleteUser     func(childComplexity int) int
 		Login          func(childComplexity int, username string, password string) int
@@ -183,7 +183,7 @@ type MutationResolver interface {
 	RefreshToken(ctx context.Context, token string) (*RefreshTokenResponse, error)
 	CreateAuthor(ctx context.Context, input AuthorCreateInput) (*Author, error)
 	UpdateAuthor(ctx context.Context, input AuthorUpdateInput) (*Author, error)
-	DeleteAuthor(ctx context.Context, input AuthorDeleteInput) (*Author, error)
+	DeleteAuthor(ctx context.Context) (*Author, error)
 	CreatePost(ctx context.Context, input PostCreateInput) (*Post, error)
 	UpdatePost(ctx context.Context, input PostUpdateInput) (*Post, error)
 	DeletePost(ctx context.Context, input PostDeleteInput) (*Post, error)
@@ -380,12 +380,7 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 			break
 		}
 
-		args, err := ec.field_Mutation_deleteAuthor_args(context.TODO(), rawArgs)
-		if err != nil {
-			return 0, false
-		}
-
-		return e.complexity.Mutation.DeleteAuthor(childComplexity, args["input"].(AuthorDeleteInput)), true
+		return e.complexity.Mutation.DeleteAuthor(childComplexity), true
 
 	case "Mutation.deletePost":
 		if e.complexity.Mutation.DeletePost == nil {
@@ -815,7 +810,6 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	ec := executionContext{rc, e}
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputAuthorCreateInput,
-		ec.unmarshalInputAuthorDeleteInput,
 		ec.unmarshalInputAuthorUpdateInput,
 		ec.unmarshalInputBooleanFilter,
 		ec.unmarshalInputFloatFilter,
@@ -940,13 +934,8 @@ input AuthorCreateInput {
 }
 
 input AuthorUpdateInput {
-    id: ID!
     firstName: String
     lastName: String
-}
-
-input AuthorDeleteInput {
-    id: ID!
 }
 
 type AuthorsPayload {
@@ -958,8 +947,9 @@ type AuthorsPayload {
 	{Name: "../schema/author_mutations.graphql", Input: `extend type Mutation {
     createAuthor(input: AuthorCreateInput!): Author!
     updateAuthor(input: AuthorUpdateInput!): Author!
-    deleteAuthor(input: AuthorDeleteInput!): Author!
-}`, BuiltIn: false},
+    deleteAuthor: Author!
+}
+`, BuiltIn: false},
 	{Name: "../schema/author_queries.graphql", Input: `extend type Query {
     author(id: ID!): Author!
     authors(pagination: Pagination!): AuthorsPayload!
@@ -1341,21 +1331,6 @@ func (ec *executionContext) field_Mutation_createUser_args(ctx context.Context, 
 	if tmp, ok := rawArgs["input"]; ok {
 		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
 		arg0, err = ec.unmarshalNUserCreateInput2goᚑtemplateᚋgqlmodelsᚐUserCreateInput(ctx, tmp)
-		if err != nil {
-			return nil, err
-		}
-	}
-	args["input"] = arg0
-	return args, nil
-}
-
-func (ec *executionContext) field_Mutation_deleteAuthor_args(ctx context.Context, rawArgs map[string]interface{}) (map[string]interface{}, error) {
-	var err error
-	args := map[string]interface{}{}
-	var arg0 AuthorDeleteInput
-	if tmp, ok := rawArgs["input"]; ok {
-		ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("input"))
-		arg0, err = ec.unmarshalNAuthorDeleteInput2goᚑtemplateᚋgqlmodelsᚐAuthorDeleteInput(ctx, tmp)
 		if err != nil {
 			return nil, err
 		}
@@ -2513,7 +2488,7 @@ func (ec *executionContext) _Mutation_deleteAuthor(ctx context.Context, field gr
 	}()
 	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
 		ctx = rctx // use context from middleware stack in children
-		return ec.resolvers.Mutation().DeleteAuthor(rctx, fc.Args["input"].(AuthorDeleteInput))
+		return ec.resolvers.Mutation().DeleteAuthor(rctx)
 	})
 	if err != nil {
 		ec.Error(ctx, err)
@@ -2554,17 +2529,6 @@ func (ec *executionContext) fieldContext_Mutation_deleteAuthor(ctx context.Conte
 			}
 			return nil, fmt.Errorf("no field named %q was found under type Author", field.Name)
 		},
-	}
-	defer func() {
-		if r := recover(); r != nil {
-			err = ec.Recover(ctx, r)
-			ec.Error(ctx, err)
-		}
-	}()
-	ctx = graphql.WithFieldContext(ctx, fc)
-	if fc.Args, err = ec.field_Mutation_deleteAuthor_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
-		ec.Error(ctx, err)
-		return
 	}
 	return fc, nil
 }
@@ -7238,34 +7202,6 @@ func (ec *executionContext) unmarshalInputAuthorCreateInput(ctx context.Context,
 	return it, nil
 }
 
-func (ec *executionContext) unmarshalInputAuthorDeleteInput(ctx context.Context, obj interface{}) (AuthorDeleteInput, error) {
-	var it AuthorDeleteInput
-	asMap := map[string]interface{}{}
-	for k, v := range obj.(map[string]interface{}) {
-		asMap[k] = v
-	}
-
-	fieldsInOrder := [...]string{"id"}
-	for _, k := range fieldsInOrder {
-		v, ok := asMap[k]
-		if !ok {
-			continue
-		}
-		switch k {
-		case "id":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
-			it.ID, err = ec.unmarshalNID2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-		}
-	}
-
-	return it, nil
-}
-
 func (ec *executionContext) unmarshalInputAuthorUpdateInput(ctx context.Context, obj interface{}) (AuthorUpdateInput, error) {
 	var it AuthorUpdateInput
 	asMap := map[string]interface{}{}
@@ -7273,21 +7209,13 @@ func (ec *executionContext) unmarshalInputAuthorUpdateInput(ctx context.Context,
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"id", "firstName", "lastName"}
+	fieldsInOrder := [...]string{"firstName", "lastName"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "id":
-			var err error
-
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("id"))
-			it.ID, err = ec.unmarshalNID2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
 		case "firstName":
 			var err error
 
@@ -9759,11 +9687,6 @@ func (ec *executionContext) marshalNAuthor2ᚖgoᚑtemplateᚋgqlmodelsᚐAuthor
 
 func (ec *executionContext) unmarshalNAuthorCreateInput2goᚑtemplateᚋgqlmodelsᚐAuthorCreateInput(ctx context.Context, v interface{}) (AuthorCreateInput, error) {
 	res, err := ec.unmarshalInputAuthorCreateInput(ctx, v)
-	return res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) unmarshalNAuthorDeleteInput2goᚑtemplateᚋgqlmodelsᚐAuthorDeleteInput(ctx context.Context, v interface{}) (AuthorDeleteInput, error) {
-	res, err := ec.unmarshalInputAuthorDeleteInput(ctx, v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 

--- a/gqlmodels/generatedmodels.go
+++ b/gqlmodels/generatedmodels.go
@@ -19,12 +19,7 @@ type AuthorCreateInput struct {
 	LastName  string `json:"lastName"`
 }
 
-type AuthorDeleteInput struct {
-	ID string `json:"id"`
-}
-
 type AuthorUpdateInput struct {
-	ID        string  `json:"id"`
 	FirstName *string `json:"firstName"`
 	LastName  *string `json:"lastName"`
 }

--- a/resolver/author_mutations.resolvers.go
+++ b/resolver/author_mutations.resolvers.go
@@ -6,14 +6,15 @@ package resolver
 
 import (
 	"context"
-	"go-template/daos"
-	"go-template/gqlmodels"
-	"go-template/models"
-	"go-template/pkg/utl/cnvrttogql"
-	"go-template/pkg/utl/convert"
-	"go-template/pkg/utl/resultwrapper"
 
 	null "github.com/volatiletech/null/v8"
+
+	"go-template/daos"
+	"go-template/gqlmodels"
+	"go-template/internal/middleware/auth"
+	"go-template/models"
+	"go-template/pkg/utl/cnvrttogql"
+	"go-template/pkg/utl/resultwrapper"
 )
 
 // CreateAuthor is the resolver for the createAuthor field.
@@ -25,7 +26,6 @@ func (r *mutationResolver) CreateAuthor(ctx context.Context, input gqlmodels.Aut
 		FirstName: input.FirstName,
 		LastName:  null.StringFrom(input.LastName),
 	})
-
 	if err != nil {
 		return nil, resultwrapper.ResolverSQLError(err, "author insertion")
 	}
@@ -35,7 +35,7 @@ func (r *mutationResolver) CreateAuthor(ctx context.Context, input gqlmodels.Aut
 // UpdateAuthor is the resolver for the updateAuthor field.
 func (r *mutationResolver) UpdateAuthor(ctx context.Context, input gqlmodels.AuthorUpdateInput) (*gqlmodels.Author, error) {
 	// Fetch the author
-	author, err := daos.FindAuthorByID(ctx, convert.StringToInt(input.ID))
+	author, err := daos.FindAuthorByID(ctx, auth.AuthorIDFromContext(ctx))
 	if err != nil {
 		return nil, resultwrapper.ResolverSQLError(err, "find author by id")
 	}
@@ -58,9 +58,9 @@ func (r *mutationResolver) UpdateAuthor(ctx context.Context, input gqlmodels.Aut
 }
 
 // DeleteAuthor is the resolver for the deleteAuthor field.
-func (r *mutationResolver) DeleteAuthor(ctx context.Context, input gqlmodels.AuthorDeleteInput) (*gqlmodels.Author, error) {
+func (r *mutationResolver) DeleteAuthor(ctx context.Context) (*gqlmodels.Author, error) {
 	// Fetch the author
-	author, err := daos.FindAuthorByID(ctx, convert.StringToInt(input.ID))
+	author, err := daos.FindAuthorByID(ctx, auth.AuthorIDFromContext(ctx))
 	if err != nil {
 		return nil, resultwrapper.ResolverSQLError(err, "find author by id")
 	}

--- a/resolver/user_queries.resolvers.go
+++ b/resolver/user_queries.resolvers.go
@@ -6,14 +6,15 @@ package resolver
 
 import (
 	"context"
+
+	"github.com/volatiletech/sqlboiler/v4/queries/qm"
+
 	"go-template/daos"
 	"go-template/gqlmodels"
 	"go-template/internal/middleware/auth"
 	"go-template/pkg/utl/cnvrttogql"
 	"go-template/pkg/utl/rediscache"
 	"go-template/pkg/utl/resultwrapper"
-
-	"github.com/volatiletech/sqlboiler/v4/queries/qm"
 )
 
 // Me is the resolver for the me field.
@@ -31,8 +32,11 @@ func (r *queryResolver) Me(ctx context.Context) (*gqlmodels.User, error) {
 func (r *queryResolver) Users(ctx context.Context, pagination *gqlmodels.Pagination) (*gqlmodels.UsersPayload, error) {
 	var queryMods []qm.QueryMod
 	if pagination != nil {
-		if pagination.Limit != 0 {
-			queryMods = append(queryMods, qm.Limit(pagination.Limit), qm.Offset(pagination.Page*pagination.Limit))
+		if pagination.Limit >= 0 && pagination.Page > 0 {
+			queryMods = append(queryMods,
+				qm.Limit(pagination.Limit),
+				qm.Offset((pagination.Page-1)*pagination.Limit),
+			)
 		}
 	}
 

--- a/resolver/user_queries.resolvers_test.go
+++ b/resolver/user_queries.resolvers_test.go
@@ -104,7 +104,7 @@ func initializeTestCases() []queryUsersArgs {
 			wantErr: false,
 			pagination: &fm.Pagination{
 				Limit: 1,
-				Page:  1,
+				Page:  2,
 			},
 			wantResp: testutls.MockUsers(),
 			init: func(mock sqlmock.Sqlmock) {

--- a/schema/author.graphql
+++ b/schema/author.graphql
@@ -16,13 +16,8 @@ input AuthorCreateInput {
 }
 
 input AuthorUpdateInput {
-    id: ID!
     firstName: String
     lastName: String
-}
-
-input AuthorDeleteInput {
-    id: ID!
 }
 
 type AuthorsPayload {

--- a/schema/author_mutations.graphql
+++ b/schema/author_mutations.graphql
@@ -1,5 +1,5 @@
 extend type Mutation {
     createAuthor(input: AuthorCreateInput!): Author!
     updateAuthor(input: AuthorUpdateInput!): Author!
-    deleteAuthor(input: AuthorDeleteInput!): Author!
+    deleteAuthor: Author!
 }


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
- Author mutation should not take `authorID` as input, instead get id from context

### Steps to Reproduce / Test
---------------------------------------------------


### Request
---------------------------------------------------


### Response
---------------------------------------------------
