### PR TITLE
fix: remove sleep from test files

### DIFF
--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,7 +3,6 @@ package config_test
 import (
 	"os"
 	"testing"
-	"time"
 
 	"go-template/internal/config"
 	"go-template/testutls"
@@ -73,7 +72,6 @@ func TestLoad(t *testing.T) {
 	defer cleanup()
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(10 * time.Millisecond)
 			if tt.wantErr {
 				patches := ApplyFunc(os.Getenv, func(key string) string {
 					if key == tt.errKey {

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -5,7 +5,6 @@ import (
 	. "go-template/internal/config"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -42,7 +41,6 @@ func TestGetString(t *testing.T) {
 			if tt.success {
 				os.Setenv(tt.args.key, tt.want)
 			}
-			time.Sleep(time.Microsecond)
 
 			if got := GetString(tt.args.key); got != tt.want {
 				t.Errorf("GetString() = %v, want %v", got, tt.want)

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -173,7 +173,6 @@ func TestStart(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			patches := tt.init(e, tt)
-			time.Sleep(10 * time.Millisecond)
 			if tt.getTransportCalled || tt.postTransportCalled ||
 				tt.optionsTransportCalled || tt.multipartFormTransportCalled {
 				testWithTransportCalls(t, tt)

--- a/pkg/utl/rediscache/redis_test.go
+++ b/pkg/utl/rediscache/redis_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
-	"time"
 
 	. "github.com/agiledragon/gomonkey/v2"
 	"github.com/gomodule/redigo/redis"
@@ -38,7 +37,6 @@ func Test_redisDial(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(10 * time.Millisecond)
 			if tt.wantErr {
 				ApplyFunc(redigo.Dial, func(string, string, ...redis.DialOption) (redis.Conn, error) {
 					return nil, fmt.Errorf("some error")

--- a/pkg/utl/rediscache/service_test.go
+++ b/pkg/utl/rediscache/service_test.go
@@ -467,7 +467,6 @@ func TestIncVisits(t *testing.T) {
 			defer patch.Reset()
 		}
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(10 * time.Millisecond)
 			conn.Command("INCR", tt.args.path).Expect([]byte(fmt.Sprint(tt.want)))
 			got, err := IncVisits(tt.args.path)
 			if (err != nil) != tt.wantErr {
@@ -500,7 +499,6 @@ func TestStartVisits(t *testing.T) {
 
 	for _, tt := range tests {
 		patches := tt.init(tt.args)
-		time.Sleep(10 * time.Millisecond)
 
 		t.Run(tt.name, func(t *testing.T) {
 			err := StartVisits(tt.args.path, time.Second)

--- a/pkg/utl/throttle/throttler_test.go
+++ b/pkg/utl/throttle/throttler_test.go
@@ -139,7 +139,6 @@ func TestCheck(t *testing.T) {
 	})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(10 * time.Millisecond)
 			tt.args.ctx = context.WithValue(tt.args.ctx, userIPAdress, tt.args.ip)
 			patches := ApplyFunc(os.Getenv, func(key string) string {
 				if key == "ENVIRONMENT_NAME" {

--- a/pkg/utl/zaplog/zaplog_test.go
+++ b/pkg/utl/zaplog/zaplog_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -125,7 +124,6 @@ func TestInitLogger(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			time.Sleep(10 * time.Millisecond)
 			patchEnv := gomonkey.ApplyFunc(os.Getenv, func(key string) string {
 				return "production"
 			})

--- a/resolver/auth_mutations.resolvers_test.go
+++ b/resolver/auth_mutations.resolvers_test.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -346,7 +345,6 @@ func TestLogin(
 			tt.name,
 			func(t *testing.T) {
 				patch := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				c := context.Background()
 				// Call the login mutation with the given arguments and check the response and error against the expected values
 				response, err := resolver1.Mutation().Login(c, tt.req.UserName, tt.req.Password)
@@ -549,7 +547,6 @@ func TestChangePassword(
 			func(t *testing.T) {
 				// Handle the case where there is an error while loading the configuration
 				patches := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				// Set up the context with the mock user
 				c := context.Background()
 				ctx := context.WithValue(c, testutls.UserKey, testutls.MockUser())
@@ -699,7 +696,6 @@ func TestRefreshToken(t *testing.T) {
 			func(t *testing.T) {
 				// Handle the case where authentication token is invalid
 				patches := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				// Set up the context with the mock user
 				c := context.Background()
 				ctx := context.WithValue(c, testutls.UserKey, testutls.MockUser())
@@ -751,7 +747,6 @@ func TestAuthorLogin(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			resolver := resolver.Resolver{}
 			resp, err := resolver.Mutation().AuthorLogin(
 				context.Background(), test.input.email, test.input.password,

--- a/resolver/author_mutation.resolvers_test.go
+++ b/resolver/author_mutation.resolvers_test.go
@@ -3,18 +3,18 @@ package resolver_test
 import (
 	"context"
 	"fmt"
+	"testing"
+
+	"github.com/agiledragon/gomonkey/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/volatiletech/null/v8"
+
 	"go-template/daos"
 	fm "go-template/gqlmodels"
 	"go-template/internal/middleware/auth"
 	"go-template/models"
 	"go-template/resolver"
 	"go-template/testutls"
-	"testing"
-	"time"
-
-	"github.com/agiledragon/gomonkey/v2"
-	"github.com/stretchr/testify/assert"
-	"github.com/volatiletech/null/v8"
 )
 
 func TestCreateAuthor(t *testing.T) {
@@ -70,7 +70,6 @@ func TestCreateAuthor(t *testing.T) {
 				}
 			}()
 			// sleep to reset the monkey patch
-			time.Sleep(10 * time.Millisecond)
 
 			response, err := resolver.Mutation().CreateAuthor(context.Background(), test.req)
 			assert.Equal(t, test.wantErr, err != nil)
@@ -135,7 +134,6 @@ func TestUpdateAuthor(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			resp, err := resolver.Mutation().UpdateAuthor(context.Background(), test.req)
 			assert.Equal(t, test.wantErr, err != nil, "expected: %t got: %v", test.wantErr, err)
 			if err == nil {
@@ -195,7 +193,6 @@ func TestDeleteAuthor(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			ctx := context.WithValue(context.Background(), auth.AuthorCtxKey, testutls.MockAuthor())
 			resp, err := resolver.Mutation().DeleteAuthor(ctx)
 			assert.Equal(t, test.wantErr, err != nil, "expected: %t got: %v", test.wantErr, err)

--- a/resolver/author_queries.resolvers_test.go
+++ b/resolver/author_queries.resolvers_test.go
@@ -73,7 +73,6 @@ func TestAuthor(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 
 			author, err := resolver.Query().Author(context.Background(), test.inputID)
 			assert.Equal(t, test.wantErr, err != nil,
@@ -186,7 +185,6 @@ func TestAuthors(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			authorPayload, err := resolver.Query().Authors(context.Background(), test.input)
 			assert.Equal(t, test.wantErr, err != nil,
 				"wantErr: %t, got: %v", test.wantErr, err,

--- a/resolver/post_mutations.resolvers_test.go
+++ b/resolver/post_mutations.resolvers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -67,7 +66,6 @@ func TestCreatePost(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			response, err := resolver.Mutation().CreatePost(context.Background(), test.req)
 			assert.Equal(t, test.wantErr, err != nil)
 			if err == nil {
@@ -142,7 +140,6 @@ func TestUpdatePost(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			response, err := resolver.Mutation().UpdatePost(context.Background(), test.req)
 			assert.Equal(t, test.wantErr, err != nil)
 			if err == nil {
@@ -208,7 +205,6 @@ func TestDeletePost(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			response, err := resolver.Mutation().DeletePost(context.Background(), test.req)
 			assert.Equal(t, test.wantErr, err != nil)
 			if err == nil {

--- a/resolver/post_queries.resolvers_test.go
+++ b/resolver/post_queries.resolvers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -69,7 +68,6 @@ func TestPostByID(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			response, err := resolver.Query().PostByID(context.Background(), test.id)
 			assert.Equal(t, test.wantErr, err != nil)
 			if err == nil {
@@ -164,7 +162,6 @@ func TestAllPostByAuthor(t *testing.T) {
 					patch.Reset()
 				}
 			}()
-			time.Sleep(10 * time.Millisecond)
 			response, err := resolver.Query().AllPostByAuthor(
 				context.Background(), test.pagination)
 			assert.Equal(t, test.wantErr, err != nil)

--- a/resolver/role_mutations.resolvers_test.go
+++ b/resolver/role_mutations.resolvers_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
 	"github.com/stretchr/testify/assert"
@@ -150,7 +149,6 @@ func TestCreateRole(
 			func(t *testing.T) {
 				// Apply additional monkey patches based on test case name.
 				patch := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				// Create a new context
 				c := context.Background()
 				// Call the resolver function

--- a/resolver/user_mutations.resolvers_test.go
+++ b/resolver/user_mutations.resolvers_test.go
@@ -161,7 +161,6 @@ func TestCreateUser(t *testing.T) {
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
 			patch := tt.init()
-			time.Sleep(time.Duration(100000))
 			response, err := resolver.Mutation().CreateUser(context.Background(), tt.req)
 			if tt.wantResp != nil {
 				assert.Equal(t, tt.wantResp, response)
@@ -279,7 +278,6 @@ func TestUpdateUser(
 			tt.name,
 			func(t *testing.T) {
 				patches := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				c := context.Background()
 				ctx := context.WithValue(c, testutls.UserKey, testutls.MockUser())
 				response, err := resolver1.Mutation().UpdateUser(ctx, tt.req)
@@ -373,7 +371,6 @@ func TestDeleteUser(
 			tt.name,
 			func(t *testing.T) {
 				patch := tt.init()
-				time.Sleep(10 * time.Millisecond)
 				// get user by id
 				c := context.Background()
 				ctx := context.WithValue(c, testutls.UserKey, testutls.MockUser())

--- a/resolver/user_queries.resolvers_test.go
+++ b/resolver/user_queries.resolvers_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"regexp"
 	"testing"
-	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/agiledragon/gomonkey/v2"
@@ -67,7 +66,6 @@ func TestMe(t *testing.T) {
 	resolver1 := &resolver.Resolver{}
 	for _, tt := range cases {
 		patches := tt.init(tt.args)
-		time.Sleep(10 * time.Millisecond)
 		response, err := resolver1.Query().Me(context.TODO())
 		if tt.wantResp != nil && response != nil {
 			assert.Equal(t, tt.wantResp, response)


### PR DESCRIPTION
### Ticket Link
---------------------------------------------------


### Related Links
---------------------------------------------------


### Description
---------------------------------------------------
- The sleeps were added to resolve the `gomonkey` patch reset issue
- The problem was brew installation of `go`, set the `GOROOT` to the `/usr/local/go` if you installed it that way
- Also uninstall the `go` installed from the brew using `brew uninstall go`


### Steps to Reproduce / Test
---------------------------------------------------


### Request
---------------------------------------------------


### Response
---------------------------------------------------
